### PR TITLE
Check for PR templates which aren't filled in

### DIFF
--- a/src/prs.rs
+++ b/src/prs.rs
@@ -19,6 +19,7 @@ pub struct Pr {
     pub url: String,
     pub title: String,
     pub author: GithubLogin,
+    pub body: String,
     pub state: PrState,
     pub updated_at: DateTime<chrono::Utc>,
     pub is_closed: bool,
@@ -96,6 +97,7 @@ pub async fn get_prs(
                  updated_at,
                  title,
                  state,
+                 body,
                  ..
              }| {
                 // If a user is deleted from GitHub, their User will be None - ignore PRs from deleted users.
@@ -114,6 +116,8 @@ pub async fn get_prs(
                 let updated_at = updated_at?;
                 let url = html_url?.to_string();
                 let title = title?;
+                let body = body.unwrap_or_default();
+
                 Some(Pr {
                     number,
                     url,
@@ -122,6 +126,7 @@ pub async fn get_prs(
                     updated_at,
                     repo_name,
                     title,
+                    body,
                     is_closed,
                 })
             },


### PR DESCRIPTION
Many of our trainees ignore the PR template. Rather than wasting a bunch of reviewer time on this (or just ignoring it), attempt to automate this detection.

I will also send out some changes simplifying and clarifying the template.