### PR TITLE
Normalise email addresses to lower case

### DIFF
--- a/src/github_accounts.rs
+++ b/src/github_accounts.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::collections::BTreeMap;
 
 use anyhow::Context;
 use email_address::EmailAddress;
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use sheets::types::Sheet;
 
 use crate::{
-    newtypes::{GithubLogin, Region},
+    newtypes::{new_case_insensitive_email_address, GithubLogin, Region},
     sheets::{cell_string, SheetsClient},
     Error,
 };
@@ -96,7 +96,7 @@ fn trainees_from_sheet(
                         cell_string(&cells[2]).context("Failed to read trainee region")?,
                     ),
                     github_login,
-                    email: EmailAddress::from_str(&email)
+                    email: new_case_insensitive_email_address(&email)
                         .with_context(|| format!("Failed to parse trainee email {}", email))?,
                 },
             );

--- a/src/google_groups.rs
+++ b/src/google_groups.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    str::FromStr,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Context;
 use email_address::EmailAddress;
@@ -15,6 +12,7 @@ use tower_sessions::Session;
 
 use crate::{
     google_auth::{make_redirect_uri, redirect_endpoint, GoogleScope},
+    newtypes::new_case_insensitive_email_address,
     Error, ServerState,
 };
 
@@ -98,13 +96,13 @@ pub(crate) async fn get_groups(client: &Client) -> Result<GoogleGroups, Error> {
             let members =
                 error_for_status(members.context("Failed to list Google group members")?)?;
             Ok(GoogleGroup {
-                email: EmailAddress::from_str(&group.email).with_context(|| {
+                email: new_case_insensitive_email_address(&group.email).with_context(|| {
                     format!("Failed to parse group email address {}", group.email)
                 })?,
                 members: members
                     .into_iter()
                     .map(|Member { email, .. }| {
-                        EmailAddress::from_str(&email).with_context(|| {
+                        new_case_insensitive_email_address(&email).with_context(|| {
                             format!(
                                 "Failed to parse group member email address {} (member of {})",
                                 email, group.email

--- a/src/newtypes.rs
+++ b/src/newtypes.rs
@@ -1,7 +1,12 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use case_insensitive_string::CaseInsensitiveString;
+use email_address::EmailAddress;
 use serde::{Deserialize, Serialize};
+
+pub fn new_case_insensitive_email_address(s: &str) -> Result<EmailAddress, email_address::Error> {
+    EmailAddress::from_str(&s.to_ascii_lowercase())
+}
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use anyhow::Context;
 use chrono::{DateTime, NaiveDate, Utc};
 use email_address::EmailAddress;
@@ -8,6 +6,7 @@ use sheets::types::{CellData, GridData};
 use tracing::warn;
 
 use crate::{
+    newtypes::new_case_insensitive_email_address,
     sheets::{cell_string, SheetsClient},
     Error,
 };
@@ -204,7 +203,9 @@ fn read_row(
         &cell_string(&cells[5]).context("Couldn't get sprint value from column 5")?,
     )?;
     let name = cell_string(&cells[0]).context("Failed to read name")?;
-    let email = EmailAddress::from_str(&cell_string(&cells[1]).context("Failed to read email")?)?;
+    let email = new_case_insensitive_email_address(
+        &cell_string(&cells[1]).context("Failed to read email")?,
+    )?;
     let timestamp =
         DateTime::parse_from_rfc3339(&cell_string(&cells[2]).context("Failed to read timestamp")?)
             .context("Failed to parse timestamp")?


### PR DESCRIPTION
This isn't super correct - email addresses technically are case sensitive, and also we don't ensure that all email addresses will be constructed this way in the future, but it solves a problem for now of people filling out the register with a different case of their email address than they registered with.