### PR TITLE
Remove ability to hard-code extra trainee data

### DIFF
--- a/config.prod.json
+++ b/config.prod.json
@@ -406,8 +406,5 @@
         }
       }
     }
-  },
-
-  "extra_trainee_github_mappings": {
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 use serde_env_field::EnvField;
 
-use crate::{
-    github_accounts::Trainee,
-    newtypes::{GithubLogin, Region},
-};
+use crate::newtypes::Region;
 
 #[derive(Clone, Deserialize)]
 pub struct Config {
@@ -40,9 +37,6 @@ pub struct Config {
     pub github_email_mapping_sheet_id: String,
 
     pub reviewer_staff_info_sheet_id: String,
-
-    // Legacy hack until all trainees are in the sheet.
-    pub extra_trainee_github_mappings: BTreeMap<GithubLogin, Trainee>,
 }
 
 #[derive(Clone, Deserialize)]

--- a/src/course.rs
+++ b/src/course.rs
@@ -605,14 +605,8 @@ pub async fn get_batch_members(
     github_email_mapping_sheet_id: &str,
     github_org: &str,
     batch_github_slug: &str,
-    extra_trainees: BTreeMap<GithubLogin, Trainee>,
 ) -> Result<BatchMembers, Error> {
-    let trainee_info = get_trainees(
-        sheets_client.clone(),
-        github_email_mapping_sheet_id,
-        extra_trainees,
-    )
-    .await?;
+    let trainee_info = get_trainees(sheets_client.clone(), github_email_mapping_sheet_id).await?;
 
     let members = all_pages("members", octocrab, async || {
         octocrab
@@ -654,7 +648,6 @@ pub async fn get_batch_with_submissions(
     github_org: &str,
     batch_github_slug: &str,
     course: &Course,
-    extra_trainees: BTreeMap<GithubLogin, Trainee>,
 ) -> Result<Batch, Error> {
     let register_info = get_register(
         sheets_client.clone(),
@@ -670,7 +663,6 @@ pub async fn get_batch_with_submissions(
         github_email_mapping_sheet_id,
         github_org,
         batch_github_slug,
-        extra_trainees,
     )
     .await?;
 

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -201,7 +201,6 @@ pub async fn get_region(
     let trainees = get_trainees(
         sheets_client,
         &server_state.config.github_email_mapping_sheet_id,
-        server_state.config.extra_trainee_github_mappings,
     )
     .await?;
     Ok(Json(Region {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -116,7 +116,6 @@ pub async fn get_trainee_batch(
         github_org,
         &batch_github_slug,
         &course,
-        server_state.config.extra_trainee_github_mappings,
     )
     .await?;
     batch

--- a/src/github_accounts.rs
+++ b/src/github_accounts.rs
@@ -15,7 +15,6 @@ use crate::{
 pub(crate) async fn get_trainees(
     client: SheetsClient,
     sheet_id: &str,
-    extra_trainees: BTreeMap<GithubLogin, Trainee>,
 ) -> Result<BTreeMap<GithubLogin, Trainee>, Error> {
     const EXPECTED_SHEET_NAME: &str = "Form responses 1";
     let data = client.get(sheet_id, true, &[]).await.map_err(|err| {
@@ -34,7 +33,7 @@ pub(crate) async fn get_trainees(
         }
     });
     if let Some(sheet) = sheet {
-        let data = trainees_from_sheet(&sheet, extra_trainees).map_err(|err| {
+        let data = trainees_from_sheet(&sheet).map_err(|err| {
             err.with_context(|| {
                 format!(
                     "Failed to read trainees from sheet {}",
@@ -64,11 +63,8 @@ pub struct Trainee {
     pub email: EmailAddress,
 }
 
-fn trainees_from_sheet(
-    sheet: &Sheet,
-    extra_trainees: BTreeMap<GithubLogin, Trainee>,
-) -> Result<BTreeMap<GithubLogin, Trainee>, Error> {
-    let mut trainees = extra_trainees;
+fn trainees_from_sheet(sheet: &Sheet) -> Result<BTreeMap<GithubLogin, Trainee>, Error> {
+    let mut trainees = BTreeMap::new();
     for data in &sheet.data {
         if data.start_column != 0 || data.start_row != 0 {
             return Err(Error::Fatal(anyhow::anyhow!("Reading data from Google Sheets API - got data chunk that didn't start at row=0,column=0 - got row={},column={}", data.start_row, data.start_column)));


### PR DESCRIPTION
We used to have this so that we could patch in trainees who hadn't filled in the spreadsheet with their GitHub accounts.

All trainees are now present in the sheet, so we don't need to patch people in any more.