### PR TITLE
Add dummy sprints to handle course rearrangement

### DIFF
--- a/config.prod.json
+++ b/config.prod.json
@@ -271,7 +271,8 @@
               {
                 "London": "2025-03-22",
                 "West Midlands": "2025-03-22"
-              }
+              },
+              {}
             ],
             "Module-Logic": [
               {
@@ -343,7 +344,8 @@
                 "Glasgow": "2025-08-02",
                 "South Africa": "2025-08-02",
                 "West Midlands": "2025-08-02"
-              }
+              },
+              {}
             ],
             "Module-Logic": [
               {


### PR DESCRIPTION
A sprint moved from Decomposition to Tools

This breaks older cohorts - give them a dummy sprint.

This means that for older cohorts we won't see their Decomposition 4 progress/results, and will see them missing a Tools sprint.