### PR TITLE
Fix attendance sheet filtering

### DIFF
--- a/src/register.rs
+++ b/src/register.rs
@@ -105,7 +105,7 @@ fn read_module(
     for (row_number, cells) in sheet_data.into_iter().enumerate() {
         // Some sheets have documentation or pivot table
         if row_number == 0 && !cells.is_empty() && cell_string(&cells[0]) != "Name" {
-            continue;
+            return Ok(sprints);
         }
         if cells.len() < 7 {
             return Err(anyhow::anyhow!(


### PR DESCRIPTION
This bug was introduced in aa0d5787598ab8191f6429b6858f3b62dd2a6f9f - it used to continue out of an outer loop to the next sheet, but now the continue just skips to the next row.

This function now handles just one sheet, so if a sheet is not a register sheet, just return immediately.